### PR TITLE
Fix unnamed Roborock map imports

### DIFF
--- a/custom_components/eufy_vacuum/rooms/source_refresh.py
+++ b/custom_components/eufy_vacuum/rooms/source_refresh.py
@@ -120,18 +120,41 @@ def _extract_maps_list(
     return []
 
 
+def _active_map_id_from_config(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    vacuum_entity_id: str,
+) -> str | None:
+    """Return the adapter-declared active map value if it is currently valid."""
+    active_map_entity = (config.get("entities") or {}).get("active_map")
+    if not active_map_entity:
+        return None
+
+    state = hass.states.get(active_map_entity)
+    if state is None:
+        return None
+
+    value = str(state.state).strip()
+    if value in {"", "unknown", "unavailable", "none", "None"}:
+        return None
+
+    return value
+
+
 def flatten_maps_response(
     response: Any,
     *,
     discovery: dict[str, Any],
     vacuum_entity_id: str | None = None,
+    active_map_id: str | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     """Flatten a get_maps response into per-map normalized room lists.
 
     Each map's ``rooms`` value is a ``{segment_id_str: name}`` mapping; this
     rewrites it into a list of ``{<room_id_key>: id, <room_name_key>: name}``
     dicts — exactly the list-of-dicts shape the attribute-source discovery path
-    already iterates. Map keys are the map NAME (matches ``entities.active_map``).
+    already iterates. Map keys are the map NAME when present, or the active-map
+    select value / map flag fallback when HA's Roborock response omits the name.
 
     Defensive against an already-list ``rooms`` value (returned as-is) and skips
     malformed entries. ``room_id_key``/``room_name_key`` default to the Roborock
@@ -145,12 +168,24 @@ def flatten_maps_response(
     maps = _extract_maps_list(response, vacuum_entity_id=vacuum_entity_id)
     out: dict[str, list[dict[str, Any]]] = {}
 
-    for map_entry in maps:
+    active_map_id = str(active_map_id).strip() if active_map_id else None
+
+    for index, map_entry in enumerate(maps):
         if not isinstance(map_entry, dict):
             continue
         map_name = str(map_entry.get(map_name_key, "")).strip()
         if not map_name:
-            continue
+            # HA's Roborock integration can return an unnamed map while the
+            # active-map select reports a synthetic name such as "Map 0".
+            # Keep the cache key aligned with the select so discovery can find
+            # the rooms it just refreshed. If there is no active-map value, use
+            # Roborock's numeric flag as the same "Map <flag>" fallback HA shows.
+            if active_map_id and len(maps) == 1:
+                map_name = active_map_id
+            elif map_entry.get("flag") is not None:
+                map_name = f"Map {map_entry['flag']}"
+            else:
+                map_name = f"Map {index}"
 
         rooms = map_entry.get(rooms_key)
         seg_list: list[dict[str, Any]] = []
@@ -240,6 +275,7 @@ async def async_refresh_room_source(
         response,
         discovery=discovery,
         vacuum_entity_id=vacuum_entity_id,
+        active_map_id=_active_map_id_from_config(hass, config, vacuum_entity_id),
     )
     set_cached_room_source(hass, vacuum_entity_id, per_map)
     _LOGGER.debug(

--- a/custom_components/eufy_vacuum/services/setup.py
+++ b/custom_components/eufy_vacuum/services/setup.py
@@ -53,6 +53,13 @@ SERVICES = (
 )
 
 
+def _completed_step_result(result: object) -> bool:
+    """Return true when a setup workflow result should advance progress."""
+    if not isinstance(result, dict):
+        return True
+    return result.get("status") in {"success", "already_done"}
+
+
 _SETUP_ADD_VACUUM_SCHEMA = vol.Schema(
     {vol.Required("vacuum_entity_id"): cv.entity_id}
 )
@@ -136,13 +143,11 @@ def register(hass: HomeAssistant) -> None:
 
     async def setup_add_vacuum(call: ServiceCall) -> dict:
         result = await _add_vacuum(hass, call.data["vacuum_entity_id"])
-        # Stamp step complete only on a non-error result. The workflow
-        # functions today don't return a uniform status key; treat
-        # any non-{"status": "error", ...} response as success.
+        # Stamp step complete only when the workflow genuinely completed.
+        # "blocked" means the user still needs to take action, so the setup
+        # panel should not render the step as done.
         manager = hass.data.get(DOMAIN, {}).get(DATA_RUNTIME)
-        if manager is not None and (
-            not isinstance(result, dict) or result.get("status") != "error"
-        ):
+        if manager is not None and _completed_step_result(result):
             _record_setup_step(
                 manager, call.data["vacuum_entity_id"], "add_vacuum"
             )
@@ -165,9 +170,7 @@ def register(hass: HomeAssistant) -> None:
     async def setup_import_active_map(call: ServiceCall) -> dict:
         result = await _import_active_map(hass, call.data["vacuum_entity_id"])
         manager = hass.data.get(DOMAIN, {}).get(DATA_RUNTIME)
-        if manager is not None and (
-            not isinstance(result, dict) or result.get("status") != "error"
-        ):
+        if manager is not None and _completed_step_result(result):
             _record_setup_step(
                 manager, call.data["vacuum_entity_id"], "import_active_map"
             )

--- a/tests/integration/test_services_errors_setup.py
+++ b/tests/integration/test_services_errors_setup.py
@@ -37,6 +37,7 @@ from custom_components.eufy_vacuum.const import (
     SERVICE_SETUP_FORCE_REMOVE_ROOM,
     SERVICE_SETUP_GET_MAP_ROOMS,
     SERVICE_SETUP_GET_STATUS,
+    SERVICE_SETUP_IMPORT_MAP,
     SERVICE_SETUP_REJECT_ROOMS,
     SERVICE_SETUP_SAVE_ROOMS,
     SERVICE_SETUP_SET_MAP_CAMERA,
@@ -203,9 +204,37 @@ async def test_setup_import_active_map(hass, manager_with_services, _no_panel):
         {"id": 1, "name": "Kitchen"}, {"id": 2, "name": "Bath"}]})
     await _call(hass, SERVICE_SETUP_ADD_VACUUM, {"vacuum_entity_id": _VAC})
     hass.states.async_set("sensor.alfred_active_map", "svsimp")
-    result = await _call(hass, "setup_import_active_map", {"vacuum_entity_id": _VAC})
+    result = await _call(hass, SERVICE_SETUP_IMPORT_MAP, {"vacuum_entity_id": _VAC})
     assert result["status"] == "success"
     assert result["data"]["room_count"] == 2
+    steps = manager_with_services.data["setup_progress"][_VAC]["completed_steps"]
+    assert "import_active_map" in steps
+
+
+async def test_setup_import_active_map_blocked_does_not_complete_step(
+    hass, manager_with_services
+):
+    """[SVS-8b] a blocked import leaves the setup step incomplete."""
+    register_adapter_config(_VAC, {
+        "adapter_id": "t", "source": "t",
+        "entities": {"active_map": "sensor.alfred_active_map"},
+        "discovery": {
+            "room_list_entity": "vacuum_entity", "room_list_attribute": "segments",
+            "room_id_key": "id", "room_name_key": "name"},
+    })
+    manager_with_services.ensure_vacuum_record(vacuum_entity_id=_VAC)
+    hass.states.async_set(_VAC, "docked", {"segments": []})
+    hass.states.async_set("sensor.alfred_active_map", "empty")
+
+    result = await _call(hass, SERVICE_SETUP_IMPORT_MAP, {"vacuum_entity_id": _VAC})
+
+    assert result["status"] == "blocked"
+    steps = (
+        manager_with_services.data.get("setup_progress", {})
+        .get(_VAC, {})
+        .get("completed_steps", [])
+    )
+    assert "import_active_map" not in steps
 
 
 async def test_setup_delete_map(hass, manager_with_services):

--- a/tests/integration/test_setup_workflow.py
+++ b/tests/integration/test_setup_workflow.py
@@ -168,8 +168,8 @@ async def test_import_active_map_success(hass, manager, _no_panel):
 async def test_import_active_map_service_response(hass, manager, _no_panel):
     """[SW-9b] A service-response brand (Roborock get_maps): import_active_map
     refreshes the get_maps source first, discovers rooms, and creates the map
-    bucket — the path that makes Configure Rooms work for a brand whose room list
-    is a service response, not an entity attribute."""
+    bucket — including Roborock responses whose map name is blank while the HA
+    active-map select reports a synthetic name such as "Map 0"."""
     from homeassistant.core import SupportsResponse
 
     register_adapter_config(_VAC, {
@@ -184,21 +184,22 @@ async def test_import_active_map_service_response(hass, manager, _no_panel):
     })
 
     async def _get_maps(call):
-        return {"maps": [{"flag": 0, "name": "Main floor",
-                          "rooms": {"16": "KITCHEN", "17": "Dining Room"}}]}
+        return {_VAC: {"maps": [{"flag": 0, "name": "",
+                                 "rooms": {"16": "KITCHEN", "17": "Dining Room"}}]}}
 
     hass.services.async_register(
         "roborock", "get_maps", _get_maps, supports_response=SupportsResponse.ONLY,
     )
     hass.states.async_set(_VAC, "docked")
-    hass.states.async_set("select.alfred_selected_map", "Main floor")
+    hass.states.async_set("select.alfred_selected_map", "Map 0")
     await add_vacuum(hass, _VAC)
 
     result = await import_active_map(hass, _VAC)
 
     assert result["status"] == "success"
     assert result["data"]["room_count"] == 2
-    rooms = manager.data["maps"][_VAC]["Main floor"]["rooms"]
+    assert result["data"]["map_id"] == "Map 0"
+    rooms = manager.data["maps"][_VAC]["Map 0"]["rooms"]
     assert {r["name"] for r in rooms.values()} == {"KITCHEN", "Dining Room"}
 
 

--- a/tests/unit/test_rooms_source_refresh.py
+++ b/tests/unit/test_rooms_source_refresh.py
@@ -10,7 +10,7 @@ Coverage targets
 [SR-1]  flatten turns {id:name} rooms into list-of-dicts keyed by map name.
 [SR-2]  flatten unwraps a per-entity response wrapper.
 [SR-3]  flatten accepts a bare maps list + already-list rooms.
-[SR-4]  flatten skips malformed map entries / nameless maps.
+[SR-4]  flatten skips malformed map entries and names nameless maps.
 [SR-5]  cache get/set round-trips; empty -> {}.
 [SR-6]  async_refresh calls the service + caches for service_response sources.
 [SR-7]  async_refresh is a no-op for attribute sources / missing maps_service.
@@ -106,13 +106,26 @@ def test_flatten_bare_list_and_list_rooms():
     assert already_list["Up"] == [{"segment_id": "5", "name": "Loft"}]
 
 
-def test_flatten_skips_bad_entries():
-    """[SR-4] non-dict entries + nameless maps are skipped."""
+def test_flatten_skips_bad_entries_and_names_unnamed_maps():
+    """[SR-4] non-dict entries are skipped; nameless maps get a fallback key."""
     out = flatten_maps_response(
         {"maps": ["junk", {"rooms": {"1": "X"}}, {"name": "Real", "rooms": {"2": "Y"}}]},
         discovery=_DISCOVERY,
     )
-    assert set(out) == {"Real"}
+    assert set(out) == {"Map 1", "Real"}
+    assert out["Map 1"] == [{"segment_id": "1", "name": "X"}]
+
+
+def test_flatten_uses_active_map_for_single_unnamed_map():
+    """[SR-4] Roborock can return name="" while the active map select says Map 0."""
+    out = flatten_maps_response(
+        {_VAC: {"maps": [{"flag": 0, "name": "", "rooms": {"16": "Спальня"}}]}},
+        discovery=_DISCOVERY,
+        vacuum_entity_id=_VAC,
+        active_map_id="Map 0",
+    )
+    assert set(out) == {"Map 0"}
+    assert out["Map 0"] == [{"segment_id": "16", "name": "Спальня"}]
 
 
 def test_flatten_unrecognized_response_empty():
@@ -149,6 +162,27 @@ async def test_async_refresh_caches(hass):
     await async_refresh_room_source(hass, _VAC)
     cache = get_cached_room_source(hass, _VAC)
     assert {r["segment_id"] for r in cache["Main floor"]} == {"16", "17", "20"}
+
+
+async def test_async_refresh_caches_unnamed_map_by_active_select(hass):
+    """[SR-6] unnamed Roborock map is cached under the active-map select value."""
+    clear_registry()
+    _service_response_adapter()
+
+    async def _get_maps(call):
+        return {_VAC: {"maps": [{"flag": 0, "name": "", "rooms": {"16": "KITCHEN"}}]}}
+
+    hass.services.async_register(
+        "roborock", "get_maps", _get_maps, supports_response=SupportsResponse.ONLY
+    )
+    hass.states.async_set(_VAC, "docked")
+    hass.states.async_set("select.ivy_selected_map", "Map 0")
+
+    await async_refresh_room_source(hass, _VAC)
+
+    cache = get_cached_room_source(hass, _VAC)
+    assert list(cache) == ["Map 0"]
+    assert cache["Map 0"] == [{"segment_id": "16", "name": "KITCHEN"}]
 
 
 async def test_async_refresh_skips_unavailable_entity(hass):


### PR DESCRIPTION
## Summary

- Keep Roborock service-response room imports working when `roborock.get_maps` returns a map with an empty `name`.
- Cache a single unnamed map under the active-map select value, such as `Map 0`, and fall back to `Map <flag>` when no active-map value is available.
- Only mark setup steps complete for `success` and `already_done`; `blocked` setup results now stay incomplete in the setup panel.
- Add unit and integration regression coverage for unnamed Roborock maps and blocked setup progress.

## Problem Solved

On a real Roborock S7, the Home Assistant `roborock.get_maps` service returned the room data under the target entity wrapper, with a map shaped like:

```json
{
  "flag": 0,
  "name": "",
  "rooms": {
    "16": "Спальня",
    "17": "Кабинет",
    "18": "Зал",
    "19": "Коридор",
    "20": "Ванная",
    "21": "Гостевой туалет",
    "22": "Детская"
  }
}
```

The Roborock app had room segmentation configured, and Home Assistant's selected-map entity reported `Map 0`, but Vacuum Agent skipped the unnamed map because the map key came only from `name`. The setup panel then showed "No rooms detected" even though the rooms were present in the service response.

There was a second UI-progress issue in the same flow: `setup_import_active_map` returned `blocked`, but the setup service still recorded the step as completed because it treated every non-error response as success. That could make the setup checklist look complete while the user still needed to fix/import rooms.

## Tested With

- Robot vacuum: Roborock S7
- Roborock model/entity context: `roborock.vacuum.a15`, `vacuum.roborock_s7`
- Home Assistant Core: `2026.6.4`
- Live verification: after applying the patch locally, `setup_import_active_map` imported 7 rooms from the Roborock S7 map and the setup status became complete.

## Validation

- `python3 -m py_compile custom_components/eufy_vacuum/rooms/source_refresh.py custom_components/eufy_vacuum/services/setup.py tests/unit/test_rooms_source_refresh.py tests/integration/test_setup_workflow.py tests/integration/test_services_errors_setup.py`
- `/private/tmp/vacuum-agent-test-venv/bin/python -m pytest -o addopts='' tests/unit/test_rooms_source_refresh.py tests/integration/test_setup_workflow.py::test_import_active_map_service_response tests/integration/test_services_errors_setup.py::test_setup_import_active_map tests/integration/test_services_errors_setup.py::test_setup_import_active_map_blocked_does_not_complete_step`
- Local Home Assistant verification: `ha core check` passed before restart.
