### PR TITLE
Fix Roborock duration and live room tracking

### DIFF
--- a/custom_components/eufy_vacuum/adapters/roborock/adapter.py
+++ b/custom_components/eufy_vacuum/adapters/roborock/adapter.py
@@ -390,8 +390,11 @@ def register_roborock_adapter_for_vacuum(
             # so clean order != queue order) — instead of Eufy's counter-plateau /
             # timing heuristic. Tracks the last confirmed target + completes the
             # previous one when the signal moves; transit rooms (not job targets) are
-            # ignored. Assumes rooms_unique_per_job (no revisits) — true here. Eufy
-            # leaves native_transition_source False (the default) and is untouched.
+            # ignored. Roborock's native signal is a live pointer and may revisit
+            # rooms during an optimized route, so completion is left to the final job
+            # snapshot instead of treating every pointer change as proof that the
+            # previous room is permanently done. Eufy leaves native_transition_source
+            # False (the default) and is untouched.
             "enabled": True,
             "native_transition_source": True,
         },
@@ -463,7 +466,7 @@ def register_roborock_adapter_for_vacuum(
             "supports_robot_position": caps.get("supports_robot_position", False),
             # Conservative defaults pending a live segment-clean run (Wave 2).
             "position_lock_reliable": False,
-            "rooms_unique_per_job": True,
+            "rooms_unique_per_job": False,
             # Reusable room PROFILES bundle multiple per-room settings (mode,
             # water, intensity, passes, edge). The S6 exposes only per-room fan
             # (everything else is global/unsettable), so a "profile" would be a

--- a/custom_components/eufy_vacuum/core/manager.py
+++ b/custom_components/eufy_vacuum/core/manager.py
@@ -3191,6 +3191,12 @@ class EufyVacuumManager:
                 threshold = self._timing_completion_threshold_minutes(current_room_entry)
                 if current_room_elapsed_minutes >= threshold:
                     awaiting_bounds_exit = True
+        _adapter_capabilities = (_get_adapter_config(vacuum_entity_id) or {}).get("capabilities", {})
+        if (
+            isinstance(_adapter_capabilities, dict)
+            and _adapter_capabilities.get("honors_clean_order") is False
+        ):
+            awaiting_bounds_exit = False
 
         # ------------------------------------------------------------------
         # Run anomalies: stall (hard) + running_long (soft) + skipped

--- a/custom_components/eufy_vacuum/jobs/active_job.py
+++ b/custom_components/eufy_vacuum/jobs/active_job.py
@@ -657,7 +657,13 @@ class ActiveJobTracker:
         passed-in computed locals — it does NOT recompute the timeline or rollover; the
         composer hands in awaiting_bounds_exit / current_room_id / elapsed already resolved.
         Returns the anomaly fields for the snapshot dict."""
-        _anomaly_cfg = (_get_adapter_config(vacuum_entity_id) or {}).get("anomaly", {})
+        _adapter_cfg = _get_adapter_config(vacuum_entity_id) or {}
+        _anomaly_cfg = _adapter_cfg.get("anomaly", {})
+        _capabilities = _adapter_cfg.get("capabilities", {})
+        _honors_clean_order = not (
+            isinstance(_capabilities, dict)
+            and _capabilities.get("honors_clean_order") is False
+        )
         _STALL_RATIO = _safe_float(_anomaly_cfg.get("stall_ratio"), 2.0)
         _RUNNING_LONG_RATIO = _safe_float(_anomaly_cfg.get("running_long_ratio"), 1.5)
         stall_detected = False
@@ -665,7 +671,7 @@ class ActiveJobTracker:
         stall_expected_minutes: float | None = None
         stall_ratio: float | None = None
 
-        if awaiting_bounds_exit and current_room_id is not None:
+        if _honors_clean_order and awaiting_bounds_exit and current_room_id is not None:
             _stall_entry = next(
                 (
                     r for r in raw_timeline
@@ -714,7 +720,12 @@ class ActiveJobTracker:
         running_long = False
         running_long_ratio: float | None = None
         running_long_room_id: int | None = None
-        if (not stall_detected) and current_room_id is not None and active_job.get("status") == "started":
+        if (
+            _honors_clean_order
+            and (not stall_detected)
+            and current_room_id is not None
+            and active_job.get("status") == "started"
+        ):
             _rl_entry = next(
                 (r for r in raw_timeline if _safe_int(r.get("room_id", -1), -1) == current_room_id),
                 None,
@@ -738,7 +749,7 @@ class ActiveJobTracker:
         # skipped (conservative): a queued room the live tracking has provably advanced
         # PAST (strictly before the current room in queue order) that is not completed.
         skipped_room_ids: list[int] = []
-        if current_room_id is not None:
+        if _honors_clean_order and current_room_id is not None:
             _queue_order = [_safe_int(r.get("room_id", -1), -1) for r in raw_timeline]
             if current_room_id in _queue_order:
                 _cur_idx = _queue_order.index(current_room_id)
@@ -1117,11 +1128,19 @@ class ActiveJobTracker:
             ~30s-polled signal never double-advances).
 
         Transit rooms (names not among the job targets) resolve to None -> ignored.
-        Assumes rooms_unique_per_job (no revisits) — true for the brands that opt in.
+        When ``capabilities.rooms_unique_per_job`` is false, the native signal is
+        treated as a live pointer only: pointer changes update the current room, but
+        they do not mark the previous room complete or reject already-seen targets.
         """
         signal_room_id = self._resolve_native_target_room_id(vacuum_entity_id, active_job)
         if signal_room_id is None:
             return active_job  # transit / dock / sentinel / unmatched -> ignore
+
+        _adapter_capabilities = (_get_adapter_config(vacuum_entity_id) or {}).get("capabilities", {})
+        rooms_unique_per_job = not (
+            isinstance(_adapter_capabilities, dict)
+            and _adapter_capabilities.get("rooms_unique_per_job") is False
+        )
 
         confirmed = _safe_int(active_job.get("_native_current_room_id", -1), -1)
         if signal_room_id == confirmed:
@@ -1130,7 +1149,7 @@ class ActiveJobTracker:
         completed_ids = {
             _safe_int(rid, -1) for rid in active_job.get("completed_room_ids", [])
         }
-        if signal_room_id in completed_ids:
+        if rooms_unique_per_job and signal_room_id in completed_ids:
             return active_job  # already finished (rooms_unique_per_job) -> ignore
 
         if confirmed < 0:
@@ -1161,7 +1180,7 @@ class ActiveJobTracker:
             map_id=map_id,
             active_job=active_job,
             new_room_id=signal_room_id,
-            complete_room_id=confirmed,
+            complete_room_id=confirmed if rooms_unique_per_job else None,
             elapsed_minutes=current_room_elapsed_minutes,
         )
 

--- a/custom_components/eufy_vacuum/learning/job_finalizer.py
+++ b/custom_components/eufy_vacuum/learning/job_finalizer.py
@@ -46,6 +46,23 @@ def _parse_iso_to_utc(value: Any) -> datetime | None:
         return None
 
 
+def _duration_state_to_seconds(raw: Any, unit: Any, default: int | None = None) -> int | None:
+    """Convert a Home Assistant duration state to seconds."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+
+    normalized_unit = str(unit or "").strip().lower()
+    if normalized_unit in {"ms", "millisecond", "milliseconds"}:
+        return int(round(value / 1000.0))
+    if normalized_unit in {"min", "mins", "minute", "minutes"}:
+        return int(round(value * 60.0))
+    if normalized_unit in {"h", "hr", "hrs", "hour", "hours"}:
+        return int(round(value * 3600.0))
+    return int(round(value))
+
+
 def _compute_total_error_seconds(
     error_latch: dict[str, Any] | None,
     *,
@@ -469,7 +486,11 @@ class LearningJobFinalizer:
                     if _ct_entity:
                         ct_state = manager.hass.states.get(_ct_entity)
                         if ct_state and ct_state.state not in ("unavailable", "unknown"):
-                            cleaning_time_seconds = _safe_int(ct_state.state, None)
+                            cleaning_time_seconds = _duration_state_to_seconds(
+                                ct_state.state,
+                                ct_state.attributes.get("unit_of_measurement"),
+                                None,
+                            )
                 if cleaning_area_m2 is None:
                     _ca_entity = _adapter_entities.get("cleaning_area")
                     if _ca_entity:

--- a/custom_components/eufy_vacuum/listeners/job_metrics.py
+++ b/custom_components/eufy_vacuum/listeners/job_metrics.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -27,6 +28,19 @@ from ..core.manager import EufyVacuumManager
 _LOGGER = logging.getLogger(__name__)
 
 _JOB_METRICS_UNSUBS = "_job_metrics_unsubs"
+
+
+def _duration_state_to_seconds(raw: Any, unit: Any) -> int:
+    """Convert a Home Assistant duration state to seconds."""
+    value = float(raw)
+    normalized_unit = str(unit or "").strip().lower()
+    if normalized_unit in {"ms", "millisecond", "milliseconds"}:
+        return int(round(value / 1000.0))
+    if normalized_unit in {"min", "mins", "minute", "minutes"}:
+        return int(round(value * 60.0))
+    if normalized_unit in {"h", "hr", "hrs", "hour", "hours"}:
+        return int(round(value * 3600.0))
+    return int(round(value))
 
 
 def remove(hass: HomeAssistant) -> None:
@@ -71,7 +85,11 @@ def register(hass: HomeAssistant) -> None:
         # entity on any adapter that doesn't expose it.
         ct_entity = entities.get("cleaning_time")
         if ct_entity:
-            watch_map[ct_entity] = (vacuum_entity_id, "last_cleaning_time_seconds", "int")
+            watch_map[ct_entity] = (
+                vacuum_entity_id,
+                "last_cleaning_time_seconds",
+                "duration_seconds",
+            )
 
         ca_entity = entities.get("cleaning_area")
         if ca_entity:
@@ -118,7 +136,15 @@ def register(hass: HomeAssistant) -> None:
             return
 
         try:
-            value = int(float(raw)) if value_type == "int" else float(raw)
+            if value_type == "duration_seconds":
+                value = _duration_state_to_seconds(
+                    raw,
+                    getattr(new_state_obj, "attributes", {}).get("unit_of_measurement"),
+                )
+            elif value_type == "int":
+                value = int(float(raw))
+            else:
+                value = float(raw)
         except (TypeError, ValueError):
             return
 

--- a/tests/integration/test_listeners_active.py
+++ b/tests/integration/test_listeners_active.py
@@ -79,6 +79,9 @@ def _mgr(hass):
     # Atomic jobs never advance a phase — the completion hook awaits this and
     # finalizes when it returns False.
     m.maybe_advance_phase = AsyncMock(return_value=False)
+    # Lifecycle probes external/app-started runs before internal job finalization.
+    # Most tests in this file exercise internal jobs, so keep that branch inert.
+    m.maybe_handle_external_run = AsyncMock(return_value=False)
     hass.data.setdefault(DOMAIN, {})[DATA_RUNTIME] = m
     return m
 

--- a/tests/integration/test_listeners_active.py
+++ b/tests/integration/test_listeners_active.py
@@ -544,12 +544,9 @@ async def test_lifecycle_recharge_suppresses_finalize_until_binary_clears(hass):
         await hass.async_block_till_done()
         assert finished == []                                # recharge -> NOT finalized
         m.finalize_learning_for_active_job.assert_not_awaited()
-        # device resumes then truly finishes: binary clears, task transitions back to
-        # the completion value -> the SAME signals now finalize (guard no longer fires)
+        # device truly finishes: binary clears while task is still at the completion
+        # value, so the same watched signal set now finalizes (guard no longer fires).
         hass.states.async_set("binary_sensor.alfred_cleaning", "off")
-        hass.states.async_set("sensor.alfred_task", "cleaning")
-        await hass.async_block_till_done()
-        hass.states.async_set("sensor.alfred_task", "charging")
         await hass.async_block_till_done()
         assert len(finished) == 1
         m.finalize_learning_for_active_job.assert_awaited()

--- a/tests/integration/test_listeners_job_metrics_negative.py
+++ b/tests/integration/test_listeners_job_metrics_negative.py
@@ -130,8 +130,8 @@ def _event(entity_id, new_state):
     return Event("state_changed", {"entity_id": entity_id, "new_state": new_state})
 
 
-def _state(entity_id, value):
-    return State(entity_id, value)
+def _state(entity_id, value, attributes=None):
+    return State(entity_id, value, attributes or {})
 
 
 # ---------------------------------------------------------------------------
@@ -296,7 +296,23 @@ async def test_valid_value_records_positive_control(hass, manager, monkeypatch):
     assert len(calls["sensor"]) == 1
     assert calls["sensor"][0]["vacuum_entity_id"] == _VAC
     assert calls["sensor"][0]["key"] == "last_cleaning_time_seconds"
-    assert calls["sensor"][0]["value"] == 300  # int conversion (value_type "int")
+    assert calls["sensor"][0]["value"] == 300  # duration defaults to seconds
     # cleaning_time changes also append a counter sample
     assert len(calls["counter"]) == 1
     assert calls["counter"][0]["vacuum_entity_id"] == _VAC
+
+
+async def test_duration_unit_minutes_records_seconds(hass, manager, monkeypatch):
+    """Roborock exposes cleaning_time as a HA duration sensor in minutes; the
+    active job stores the canonical seconds value used by learning."""
+    handler = _capture_handler(hass, manager, monkeypatch)
+    _seed_active_job(manager)
+    calls = _spy_recorders(manager, monkeypatch)
+
+    handler(_event(
+        _CLEANING_TIME_ENTITY,
+        _state(_CLEANING_TIME_ENTITY, "6.15", {"unit_of_measurement": "min"}),
+    ))
+
+    assert calls["sensor"][0]["key"] == "last_cleaning_time_seconds"
+    assert calls["sensor"][0]["value"] == 369

--- a/tests/integration/test_native_rollover.py
+++ b/tests/integration/test_native_rollover.py
@@ -22,6 +22,8 @@ Coverage targets
         robot's dock room is not phantom-completed when it leaves to clean phase 0.
 [NR-11] regression: a grouped (no-phases) job STILL rolls through the caller — the
         sequenced guard didn't break the grouped path.
+[NR-12] non-unique native room signal -> pointer updates without auto-completing
+        the previous room.
 """
 
 from __future__ import annotations
@@ -52,13 +54,16 @@ def tracker(manager) -> ActiveJobTracker:
     return ActiveJobTracker(manager)
 
 
-def _register(native: bool = True):
+def _register(native: bool = True, *, rooms_unique: bool | None = None):
     clear_registry()
-    register_adapter_config(_VAC, {
+    config = {
         "adapter_id": "rb", "source": "code",
         "entities": {"active_cleaning_target": _SIGNAL},
         "live_transition": {"enabled": True, "native_transition_source": native},
-    })
+    }
+    if rooms_unique is not None:
+        config["capabilities"] = {"rooms_unique_per_job": rooms_unique}
+    register_adapter_config(_VAC, config)
 
 
 def _seed(manager, *, current, completed=None, native_confirmed=None):
@@ -154,6 +159,17 @@ async def test_already_completed_target_ignored(tracker, manager):
     result = await _roll(tracker, manager, job, "KITCHEN")  # 16, already done
     assert result["current_room_id"] == 17
     assert result["completed_room_ids"] == [16]
+
+
+async def test_non_unique_signal_updates_pointer_without_completion(tracker, manager):
+    """[NR-12] Roborock's live current-room signal can revisit targets during an
+    optimized route, so pointer changes are not completion proof."""
+    _register(rooms_unique=False)
+    job = _seed(manager, current=16, native_confirmed=16)
+    result = await _roll(tracker, manager, job, "Heidi & Chris")  # jump to 20
+    assert result["completed_room_ids"] == []
+    assert result["current_room_id"] == 20
+    assert result["_native_current_room_id"] == 20
 
 
 async def test_sequenced_job_suppresses_native_rollover(tracker, manager):

--- a/tests/integration/test_roborock_e2e.py
+++ b/tests/integration/test_roborock_e2e.py
@@ -11,9 +11,9 @@ Flow:
      with live-resolved ids; the queue-first room's fan is pushed live (per-room
      fan via vacuum.set_fan_speed — passes is global, mop is unsettable).
   2. run starts -> lifecycle marks has_observed_active_lifecycle.
-  3. native rollover follows current_room through the device's optimized order,
-     completing the previous target on each move AND pushing that room's fan;
-     transit rooms ignored.
+  3. native rollover follows current_room through the device's optimized order
+     as a live pointer, pushing each room's fan without treating pointer changes
+     as completion proof; transit rooms ignored.
   4. completion (dock: cleaning binary off + charging) -> finalization fires via
      the require_job_active_clear gate.
 """
@@ -164,7 +164,7 @@ async def test_roborock_dispatch_rollover_completion(hass, manager, monkeypatch)
     assert calls["fan"][-1]["fan_speed"] == "quiet"             # Office fan pushed live
 
     await _tick_rollover(manager, hass, "KITCHEN")
-    assert _OFFICE in _job(manager)["completed_room_ids"]        # Office done on move
+    assert _job(manager)["completed_room_ids"] == []             # pointer move != completion
     assert _job(manager)["current_room_id"] == _KITCHEN
     assert calls["fan"][-1]["fan_speed"] == "turbo"             # Kitchen fan pushed live
 

--- a/tests/unit/test_jobs_active_job.py
+++ b/tests/unit/test_jobs_active_job.py
@@ -34,6 +34,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.eufy_vacuum.adapters.registry import clear_registry, register_adapter_config
 from custom_components.eufy_vacuum.jobs.active_job import (
     ActiveJobTracker,
     _normalize_path_block_action,
@@ -236,6 +237,48 @@ def test_timing_threshold_low_confidence_few_samples(tracker):
     room = {"minutes": 10.0, "confidence_score": 0.3, "sample_count": 1}
     # overrun 0.22 → slack max(0.75, 2.2)=2.2; sample<=1 +1.0 → 3.2; cap 4.0
     assert tracker._timing_completion_threshold_minutes(room) == pytest.approx(13.2)
+
+
+# ---------------------------------------------------------------------------
+# detect_run_anomalies
+# ---------------------------------------------------------------------------
+
+def test_detect_run_anomalies_disabled_for_path_optimized_order():
+    """A path-optimizing adapter can jump ahead of queue order without implying
+    skipped rooms or a stall in the current room."""
+    clear_registry()
+    register_adapter_config("vacuum.alfred", {
+        "adapter_id": "roborock",
+        "source": "test",
+        "capabilities": {"honors_clean_order": False},
+    })
+    manager = MagicMock()
+    manager.data = {"active_jobs": {}}
+    tracker = ActiveJobTracker(manager)
+    active_job = {
+        "status": "started",
+        "queue_room_ids": [1, 2],
+        "resolved_rooms": [{"room_id": 1, "name": "Kitchen"}, {"room_id": 2, "name": "Hall"}],
+    }
+
+    result = tracker.detect_run_anomalies(
+        vacuum_entity_id="vacuum.alfred",
+        map_id="6",
+        active_job=active_job,
+        raw_timeline=[
+            {"room_id": 1, "minutes": 1.0, "confidence_score": 0.9, "sample_count": 3},
+            {"room_id": 2, "minutes": 1.0, "confidence_score": 0.9, "sample_count": 3},
+        ],
+        current_room_id=2,
+        current_room_elapsed_minutes=10.0,
+        completed_room_ids=[],
+        awaiting_bounds_exit=True,
+    )
+
+    assert result["stall_detected"] is False
+    assert result["running_long"] is False
+    assert result["skipped_room_ids"] == []
+    manager.hass.bus.async_fire.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_learning_job_finalizer.py
+++ b/tests/unit/test_learning_job_finalizer.py
@@ -12,6 +12,7 @@ from custom_components.eufy_vacuum.learning.job_finalizer import (
     LearningJobFinalizer,
     _apply_water_actuals,
     _compute_total_error_seconds,
+    _duration_state_to_seconds,
     _parse_iso_to_utc,
 )
 
@@ -54,6 +55,24 @@ def test_parse_iso_utc_non_string_returns_none():
 
 def test_parse_iso_utc_garbage_returns_none():
     assert _parse_iso_to_utc("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# _duration_state_to_seconds
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw,unit,expected", [
+    ("300", "s", 300),
+    ("6.15", "min", 369),
+    ("0.1", "h", 360),
+    ("1500", "ms", 2),
+])
+def test_duration_state_to_seconds(raw, unit, expected):
+    assert _duration_state_to_seconds(raw, unit) == expected
+
+
+def test_duration_state_to_seconds_bad_value_default():
+    assert _duration_state_to_seconds("unavailable", "min", None) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Roborock runs exposed two issues after room import support landed:

- Home Assistant reports the Roborock S7 cleaning-time sensor as a duration in minutes, but the integration stored the raw numeric state as seconds. That made completed-job duration, estimates, and learning data too small by a factor of 60 whenever the listener or finalizer read that sensor directly.
- Roborock's native current-room signal is a live pointer during its optimized route, not proof that each previously reported room is permanently finished. Treating every pointer change as a completion produced misleading live progress, false skipped-room/stall signals, and confusing UI state during full-apartment cleans.

## Changes

- Convert HA duration sensor states to canonical seconds in both the job-metrics listener and finalizer fallback path.
- Mark Roborock native current-room updates as non-unique per job, so revisits update the live pointer without auto-completing the previous room.
- Suppress strict queue-order anomalies (`skipped`, `stall`, `running_long`, and bounds-exit polling) for adapters that declare `honors_clean_order: false`.
- Add tests for minute-to-second conversion, non-unique native-room pointer updates, and path-optimized anomaly suppression.

## Tested

Device tested: Roborock S7, Home Assistant model `roborock.vacuum.a15`.

Observed runs after the local fix:

- Two-room Vacuum Agent run: `cleaning_time_seconds=369` matched 6.15 minutes, area 6.4 m², battery 71% to 67%, no skipped/stall anomalies.
- Full-apartment run: Roborock reported 59.1 minutes, Vacuum Agent recorded 3546 seconds, area 65.7 m², battery 100% to 53%.
- Full-apartment run after anomaly suppression: Roborock reported 59.65 minutes, Vacuum Agent recorded 3579 seconds, area 76.1 m², battery 100% to 52%, no skipped/stall anomalies.

Local checks:

- `python3 -m py_compile` on changed source and test files passed.
- Targeted `python3 -m pytest ...` was not run locally because `pytest` is not installed in the available Python environment.
