### PR TITLE
fix(eufy): support scalar/Tuya (attribute-mode) devices with no active_map sensor

### DIFF
--- a/custom_components/eufy_vacuum/adapters/eufy/adapter.py
+++ b/custom_components/eufy_vacuum/adapters/eufy/adapter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from ..registry import register_adapter_config
 from .const import ADAPTER_ID, STORAGE_KEY
@@ -129,6 +130,26 @@ def _build_button_blocks(
     }
 
 
+def _registry_model_code(hass: HomeAssistant, vacuum_entity_id: str) -> str | None:
+    """Return the device-registry model code for a vacuum (e.g. ``"T2351"``).
+
+    The device registry is the RELIABLE model source across robovac_mqtt
+    transports. The novel-API path also mirrors it onto a ``detected_model``
+    vacuum-entity attribute, but the scalar/Tuya path does NOT set that
+    attribute — so reading only the attribute pinned scalar devices to
+    model_family "generic". The registry carries the code either way. Mirrors
+    ``core/manager._get_registry_model_code`` (kept local to keep the adapter
+    self-contained).
+    """
+    entity_entry = er.async_get(hass).async_get(vacuum_entity_id)
+    if entity_entry is None or not entity_entry.device_id:
+        return None
+    device_entry = dr.async_get(hass).async_get(entity_entry.device_id)
+    if device_entry is None:
+        return None
+    return str(device_entry.model or "").strip() or None
+
+
 def register_eufy_adapter_for_vacuum(
     hass: HomeAssistant,
     vacuum_entity_id: str,
@@ -146,8 +167,12 @@ def register_eufy_adapter_for_vacuum(
     from ...core.capabilities import detect_capabilities
 
     vacuum_state = hass.states.get(vacuum_entity_id)
-    detected_model = None
-    if vacuum_state is not None:
+    # Prefer the DEVICE REGISTRY model (reliable on every robovac_mqtt transport);
+    # fall back to the vacuum's `detected_model` attribute. Scalar/Tuya devices
+    # don't set that attribute, so reading only it pinned them to "generic" — but
+    # the registry has "T2351" either way.
+    detected_model = _registry_model_code(hass, vacuum_entity_id)
+    if not detected_model and vacuum_state is not None:
         detected_model = vacuum_state.attributes.get("detected_model")
 
     # Compute model family using the Eufy model catalog.

--- a/custom_components/eufy_vacuum/adapters/eufy/adapter.py
+++ b/custom_components/eufy_vacuum/adapters/eufy/adapter.py
@@ -207,12 +207,20 @@ def register_eufy_adapter_for_vacuum(
     # of whether the entity happens to be present right now. Entity presence
     # detection in detect_capabilities() is the fallback for unrecognised
     # model codes that still expose the relevant entities.
+    # Rooms can be read from the `segments` attribute even when there's no
+    # active_map sensor (scalar/Tuya transport). Flag it so detect_capabilities
+    # reports supports_rooms/segments via the attribute path (supports_active_map
+    # stays entity-gated — there's no map entity to dereference).
+    _segments = vacuum_state.attributes.get("segments") if vacuum_state is not None else None
+    has_attribute_rooms = bool(isinstance(_segments, list) and _segments)
+
     capability_hints: dict[str, bool] = {
         "supports_mop_features": model_family in {"x10", "x8", "l60", "l50"},
         "supports_mop_wash":     model_family in {"x10", "x8"},
         "supports_mop_dry":      model_family in {"x10", "x8"},
         "supports_empty_dust":   model_family in {"x10", "x8", "l60", "l50"},
         "supports_path_control": model_family in {"x10", "x8"},
+        "has_attribute_rooms":   has_attribute_rooms,
     }
 
     caps = detect_capabilities(
@@ -476,6 +484,13 @@ def register_eufy_adapter_for_vacuum(
             "room_list_attribute": "segments",
             "room_id_key": "id",
             "room_name_key": "name",
+            # Scalar/Tuya-transport Eufy devices surface the room list in the
+            # `segments` attribute but create NO active_map sensor. There is only
+            # one map on these, so anchor import/discovery to this single implicit
+            # id when no active_map entity exists (see rooms/room_discovery
+            # ._implicit_attribute_map_id). Novel devices have the entity, so the
+            # implicit id never fires for them.
+            "implicit_map_id": "main",
             # Auto-discovery cadence. The framework runs discovery on each
             # listed event plus once every interval as a safety net.
             "auto_refresh_on": [

--- a/custom_components/eufy_vacuum/core/capabilities.py
+++ b/custom_components/eufy_vacuum/core/capabilities.py
@@ -234,7 +234,14 @@ def detect_capabilities(
     robot_position_x_entity_id = robot_position_x_entity or robot_position_x_registered
     robot_position_y_entity_id = robot_position_y_entity or robot_position_y_registered
 
-    supports_rooms                  = bool(active_map_registered or active_map_entity)
+    # Rooms/segments are available either via an active_map entity OR — for
+    # attribute-mode devices that expose the room list as a vacuum attribute but
+    # create no map sensor (e.g. Eufy on the scalar/Tuya transport) — via the
+    # adapter's `has_attribute_rooms` hint. supports_active_map stays strictly
+    # entity-gated: there is no map ENTITY to read in attribute mode, so it must
+    # not be reported True (the import path uses the implicit map id instead).
+    _has_attribute_rooms            = bool(_hints.get("has_attribute_rooms"))
+    supports_rooms                  = bool(active_map_registered or active_map_entity or _has_attribute_rooms)
     supports_segments               = supports_rooms
     supports_active_map             = bool(active_map_registered or active_map_entity)
     supports_active_cleaning_target = bool(

--- a/custom_components/eufy_vacuum/core/manager.py
+++ b/custom_components/eufy_vacuum/core/manager.py
@@ -2578,18 +2578,16 @@ class EufyVacuumManager:
         return self.active_job.start_external_capture(**kwargs)
 
     def _resolve_active_map_id(self, vacuum_entity_id: str) -> str | None:
-        """Current active map id from the adapter's active_map entity (or None)."""
-        from ..adapters.registry import get_adapter_config
+        """Current active map id — the adapter's active_map entity, or (for an
+        attribute-mode device with no such entity, e.g. scalar/Tuya Eufy) the
+        adapter's implicit single map id.
 
-        cfg = get_adapter_config(vacuum_entity_id) or {}
-        entity_id = (cfg.get("entities", {}) or {}).get("active_map")
-        if not entity_id:
-            return None
-        state_obj = self.hass.states.get(entity_id)
-        value = getattr(state_obj, "state", None)
-        if value in (None, "", "unknown", "unavailable", "none"):
-            return None
-        return str(value)
+        Delegates to the brand-agnostic resolver so the import path and the
+        runtime path (external-run capture, dispatch) agree on the same id.
+        """
+        from ..rooms.room_discovery import get_active_map_id
+
+        return get_active_map_id(self.hass, vacuum_entity_id)
 
     async def maybe_handle_external_run(self, *, vacuum_entity_id: str) -> bool:
         """Detect + capture an app-started (external) run.

--- a/custom_components/eufy_vacuum/diagnostics.py
+++ b/custom_components/eufy_vacuum/diagnostics.py
@@ -97,6 +97,99 @@ def _slim_upkeep(upkeep: Any) -> Any:
     return slim
 
 
+def _self_check(out: dict[str, Any]) -> dict[str, Any]:
+    """Plain-English interpretation of the raw signals collected below.
+
+    This is the block a support helper (or the user) reads first: it turns the
+    entity-resolution / capability / segment data into status lines, so the most
+    common report — "why can't I import my rooms?" — is answerable at a glance
+    without knowing the internals. The headline tell is transport mode: a device
+    on Eufy's reduced (scalar/Tuya) transport exposes no active_map sensor, so
+    its rooms come from the vacuum's ``segments`` attribute and its map picture
+    won't render. Derived purely from the already-collected ``out`` — never
+    raises (the caller still guards it).
+    """
+    caps = out.get("capabilities") or {}
+    entity_res = out.get("entity_resolution") or {}
+    vstate = out.get("vacuum_state") or {}
+
+    active_map_role = entity_res.get("active_map") or {}
+    has_active_map_entity = bool(active_map_role.get("exists"))
+
+    seg_count = vstate.get("segment_count")
+    has_segments = isinstance(seg_count, int) and seg_count > 0
+
+    if has_active_map_entity:
+        transport = "full (novel / MQTT) — active_map sensor present"
+    elif has_segments:
+        transport = (
+            "attribute-mode (reduced / scalar-Tuya) — no active_map sensor; "
+            "the room list is read from the vacuum's segments attribute"
+        )
+    else:
+        transport = (
+            "unknown — no active_map sensor and no room segments visible yet"
+        )
+
+    if caps.get("supports_rooms"):
+        if has_active_map_entity:
+            room_control = "available (via active map)"
+        elif has_segments:
+            room_control = f"available (via segments attribute — {seg_count} rooms)"
+        else:
+            room_control = "reported available, but no rooms are visible yet"
+    else:
+        room_control = "unavailable (no room source detected)"
+
+    if has_active_map_entity:
+        map_image = (
+            "active_map sensor present — live-map backdrop available when the "
+            "eufy-clean fork provides a map camera"
+        )
+    else:
+        map_image = (
+            "unavailable — the reduced transport has no map sensor; the live-map "
+            "backdrop needs the smcneece eufy-clean fork"
+        )
+
+    detected_model = caps.get("detected_model")
+    family = caps.get("model_family")
+    if detected_model and family:
+        model_detection = f"{detected_model} → {family}"
+    elif family:
+        model_detection = str(family)
+    else:
+        model_detection = "generic (model not detected)"
+
+    importable = bool(caps.get("supports_rooms")) and (
+        bool(out.get("active_map_id")) or has_segments
+    )
+
+    if has_active_map_entity:
+        note = "Standard transport — maps, rooms and the live map all work."
+    elif has_segments:
+        note = (
+            "No active_map sensor — your robot is on Eufy's reduced (scalar/Tuya) "
+            "transport. Room cleaning works (rooms come from the vacuum's segments "
+            "attribute); the map picture won't render without the eufy-clean fork."
+        )
+    else:
+        note = (
+            "No active_map sensor and no room segments yet. If the robot is new, "
+            "finish a mapping run with rooms set up in the Eufy app — the room list "
+            "loads directly from the vacuum and may take a moment after startup."
+        )
+
+    return {
+        "transport": transport,
+        "room_control": room_control,
+        "rooms_importable": "yes" if importable else "no",
+        "map_image": map_image,
+        "model_detection": model_detection,
+        "note": note,
+    }
+
+
 def _vacuum_diagnostics(
     hass: HomeAssistant, manager: Any, vacuum_entity_id: str
 ) -> dict[str, Any]:
@@ -190,7 +283,20 @@ def _vacuum_diagnostics(
     except Exception as err:  # pragma: no cover - defensive
         out["upkeep_snapshot_error"] = repr(err)
 
-    return out
+    # Interpreted, human-readable summary of everything above. Computed last
+    # (needs all signals) but surfaced right after the id so it reads first.
+    try:
+        summary = _self_check(out)
+    except Exception as err:  # pragma: no cover - defensive
+        summary = {"error": repr(err)}
+    ordered: dict[str, Any] = {
+        "vacuum_entity_id": vacuum_entity_id,
+        "self_check": summary,
+    }
+    for key, value in out.items():
+        if key != "vacuum_entity_id":
+            ordered[key] = value
+    return ordered
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/eufy_vacuum/rooms/room_discovery.py
+++ b/custom_components/eufy_vacuum/rooms/room_discovery.py
@@ -35,27 +35,59 @@ _LOGGER = logging.getLogger(__name__)
 def get_active_map_id(hass: HomeAssistant, vacuum_entity_id: str) -> str | None:
     """Return the active map ID for a vacuum, if available.
 
-    Reads the entity declared as entities.active_map in the adapter config.
-    Returns None when the adapter is not registered, the entity is missing,
-    or its state is an HA sentinel value.
+    Reads the entity declared as entities.active_map in the adapter config. When
+    the device exposes that entity (novel Eufy / Roborock) it is the single
+    source of truth. When NO active_map entity exists at all — an attribute-mode
+    device, e.g. Eufy on the scalar/Tuya transport, which surfaces its room list
+    as a vacuum attribute but creates no map sensor — fall back to the adapter's
+    single implicit map id (see _implicit_attribute_map_id). Returns None when
+    neither path yields an id.
     """
     config = get_adapter_config(vacuum_entity_id)
     active_map_entity = (config or {}).get("entities", {}).get("active_map")
-    if not active_map_entity:
-        _LOGGER.debug("No active_map entity declared for %s", vacuum_entity_id)
-        return None
 
-    state = hass.states.get(active_map_entity)
-    if state is None:
-        _LOGGER.debug("Active map entity %s missing for %s", active_map_entity, vacuum_entity_id)
-        return None
+    if active_map_entity:
+        # Entity present: trust it exclusively. A transiently unavailable entity
+        # returns None (wait for it) rather than forking a second implicit map.
+        state = hass.states.get(active_map_entity)
+        if state is None:
+            _LOGGER.debug("Active map entity %s missing for %s", active_map_entity, vacuum_entity_id)
+            return None
+        value = state.state
+        if value in {"unknown", "unavailable", "", "none", "None"}:
+            _LOGGER.debug("Active map entity invalid value for %s: %s", vacuum_entity_id, value)
+            return None
+        return str(value)
 
-    value = state.state
-    if value in {"unknown", "unavailable", "", "none", "None"}:
-        _LOGGER.debug("Active map entity invalid value for %s: %s", vacuum_entity_id, value)
-        return None
+    # No active_map entity declared — attribute-mode fallback.
+    _LOGGER.debug("No active_map entity for %s — trying implicit attribute map", vacuum_entity_id)
+    return _implicit_attribute_map_id(hass, vacuum_entity_id, config)
 
-    return str(value)
+
+def _implicit_attribute_map_id(
+    hass: HomeAssistant, vacuum_entity_id: str, config: dict | None
+) -> str | None:
+    """Single implicit map id for an attribute-mode device (no active_map entity).
+
+    A device that exposes its room list as a vacuum-entity attribute but creates
+    no active_map sensor still has exactly one map. When the adapter declares
+    ``discovery.implicit_map_id`` AND that room-list attribute currently holds a
+    non-empty list, return the implicit id so import/discovery have an anchor.
+    Returns None otherwise — so brands that don't opt in (Roborock, which uses a
+    service-response source and sets no implicit_map_id) are unaffected, and the
+    implicit map never appears for a device with no rooms.
+    """
+    discovery = (config or {}).get("discovery", {}) or {}
+    implicit = discovery.get("implicit_map_id")
+    attr = discovery.get("room_list_attribute")
+    # Only the vacuum-attribute room source supports an implicit single map.
+    if not implicit or not attr or discovery.get("room_list_entity") != "vacuum_entity":
+        return None
+    state = hass.states.get(vacuum_entity_id)
+    rooms = state.attributes.get(attr) if state is not None else None
+    if isinstance(rooms, list) and rooms:
+        return str(implicit)
+    return None
 
 
 def discover_rooms_for_vacuum(

--- a/custom_components/eufy_vacuum/setup/workflow.py
+++ b/custom_components/eufy_vacuum/setup/workflow.py
@@ -154,9 +154,12 @@ async def import_active_map(
         return _result(
             "blocked",
             (
-                f"No active map detected for '{vacuum_entity_id}'. "
-                "Ensure the vacuum is powered on and has completed at least one "
-                "mapping run, then try again."
+                f"No map or room list detected for '{vacuum_entity_id}'. "
+                "Ensure the vacuum is powered on and has completed a mapping run "
+                "with rooms configured in your vacuum app, then try again. "
+                "(Devices on Eufy's reduced transport have no map sensor — the "
+                "room list loads directly from the vacuum and may take a moment "
+                "after startup.)"
             ),
             data={"vacuum_entity_id": vacuum_entity_id},
         )

--- a/tests/integration/test_core_capabilities.py
+++ b/tests/integration/test_core_capabilities.py
@@ -15,6 +15,8 @@ Coverage targets
 [CAP-7]  get_vacuum_capabilities: newly-known model refreshes cached caps even with refresh=False.
 [CAP-8]  detect_capabilities: an explicit supports_water_control hint wins over the
          mop-derived default (the Roborock S6 declares it False — water is unsettable).
+[CAP-9]  detect_capabilities: has_attribute_rooms hint reports rooms/segments support
+         WITHOUT a map entity (scalar/Tuya transport); supports_active_map stays False.
 """
 
 from __future__ import annotations
@@ -118,6 +120,23 @@ def test_detect_water_control_defaults_to_mop_without_hint(hass):
     )
     assert caps["supports_mop_features"] is True
     assert caps["supports_water_control"] is True
+
+
+def test_detect_attribute_rooms_hint(hass):
+    """[CAP-9] has_attribute_rooms reports room/segment support without a map
+    entity — the scalar/Tuya transport, where the room list lives in the vacuum's
+    ``segments`` attribute and there is NO active_map sensor. supports_active_map
+    must stay False: there is no map entity to dereference."""
+    hass.states.async_set(_VAC, "docked")
+    caps = detect_capabilities(
+        hass,
+        vacuum_entity_id=_VAC,
+        capability_hints={"has_attribute_rooms": True},
+    )
+    assert caps["supports_rooms"] is True
+    assert caps["supports_segments"] is True
+    assert caps["supports_active_map"] is False
+    assert caps["active_map_available"] is False
 
 
 def test_detect_robot_position_needs_both(hass):

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -20,6 +20,8 @@ Coverage targets
           a stored map still dumps that map's rooms (managed_rooms_by_map).
 [DIAG-7]  Slimming: per-item upkeep `guide` stripped, managed-rooms `summary`
           stripped, vacuum_state.rooms (== segments) dropped.
+[DIAG-8]  self_check interprets the scalar/Tuya transport (no active_map entity
+          but rooms via segments) into plain-English status lines, surfaced first.
 """
 
 from __future__ import annotations
@@ -283,3 +285,47 @@ async def test_diagnostics_rooms_without_active_map_sensor(hass):
     assert vac["active_map_id"] is None
     assert vac["managed_rooms_by_map"] == {"Main floor": {"room_count": 10}}
     assert "managed_rooms_note" not in vac
+
+
+async def test_diagnostics_self_check_attribute_mode(hass):
+    """[DIAG-8] self_check interprets the scalar/Tuya transport.
+
+    No active_map entity, but the room list is present in the vacuum's `segments`
+    attribute (Peter's X10 Pro Omni). The summary should read: attribute-mode
+    transport, rooms importable, map image needs the fork, model resolved — and
+    appear as the first block after the vacuum id."""
+    caps = {
+        "entities": {"vacuum": VACUUM},  # NO active_map entity (scalar transport)
+        "detected_model": "T2351",
+        "model_family": "x10",
+        "supports_rooms": True,
+        "supports_segments": True,
+        "supports_active_map": False,
+    }
+    manager = _FakeManager(
+        caps=caps,
+        maps={"vacuum_entity_id": VACUUM, "map_count": 1,
+              "maps": [{"map_id": "main", "room_count": 2}]},
+        rooms={"rooms": [{"room_id": 1, "name": "Kitchen"}]},
+        upkeep={"highest_priority_status": "good"},
+        dashboard={},
+    )
+    hass.data.setdefault(DOMAIN, {})[DATA_RUNTIME] = manager
+    hass.states.async_set(VACUUM, "docked", {
+        "segments": [{"id": 1, "name": "Kitchen"}, {"id": 2, "name": "Hall"}],
+    })
+
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+    vac = diag["vacuums"][0]
+    sc = vac["self_check"]
+
+    assert "attribute-mode" in sc["transport"]
+    assert sc["rooms_importable"] == "yes"
+    assert "segments attribute" in sc["room_control"]
+    assert "eufy-clean fork" in sc["map_image"]
+    assert sc["model_detection"] == "T2351 → x10"
+    # Surfaced as the first signal, right after the id.
+    assert list(vac.keys())[:2] == ["vacuum_entity_id", "self_check"]

--- a/tests/integration/test_room_discovery.py
+++ b/tests/integration/test_room_discovery.py
@@ -10,6 +10,12 @@ Coverage targets
 [RD-4] discover_rooms_for_vacuum: incomplete discovery config → [].
 [RD-5] discover_rooms_payload wraps the room list with counts.
 [RD-6] room_list_entity = concrete entity id sources from that entity, not the vacuum.
+[RD-7] attribute mode (no active_map entity) + implicit_map_id + segments → implicit id.
+[RD-8] implicit_map_id declared but no rooms visible → None (no phantom map).
+[RD-9] a declared active_map entity wins; implicit never fires alongside it.
+[RD-10] a declared-but-unavailable active_map entity → None (must not fork an implicit map).
+[RD-11] implicit map only applies to the vacuum-attribute source.
+[RD-12] end-to-end: scalar/Tuya path imports rooms under the implicit id.
 """
 
 from __future__ import annotations
@@ -87,6 +93,92 @@ def test_discover_payload(hass, manager):
     payload = discover_rooms_payload(hass, vacuum_entity_id=_VAC)
     assert payload["room_count"] == 1
     assert payload["active_map_id"] == "6"
+
+
+def _attribute_mode_adapter(*, implicit="main", room_list_entity="vacuum_entity"):
+    """Adapter with NO active_map entity (scalar/Tuya Eufy) + an implicit map id."""
+    register_adapter_config(_VAC, {
+        "adapter_id": "test", "source": "test",
+        "entities": {},  # the scalar transport creates no active_map sensor
+        "discovery": {
+            "room_list_entity": room_list_entity,
+            "room_list_attribute": "segments",
+            "room_id_key": "id",
+            "room_name_key": "name",
+            "implicit_map_id": implicit,
+        },
+    })
+
+
+def test_active_map_implicit_attribute_mode(hass, manager):
+    """[RD-7] no active_map entity + implicit_map_id + segments → implicit id."""
+    _attribute_mode_adapter()
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    assert get_active_map_id(hass, _VAC) == "main"
+
+
+def test_active_map_implicit_no_segments(hass, manager):
+    """[RD-8] implicit declared but no rooms visible → None (no phantom map)."""
+    _attribute_mode_adapter()
+    hass.states.async_set(_VAC, "docked", {"segments": []})
+    assert get_active_map_id(hass, _VAC) is None
+    hass.states.async_set(_VAC, "docked", {})  # attribute entirely absent
+    assert get_active_map_id(hass, _VAC) is None
+
+
+def test_active_map_entity_wins_over_implicit(hass, manager):
+    """[RD-9] a present active_map entity wins; implicit never fires alongside it."""
+    register_adapter_config(_VAC, {
+        "adapter_id": "test", "source": "test",
+        "entities": {"active_map": "sensor.alfred_map"},
+        "discovery": {
+            "room_list_entity": "vacuum_entity", "room_list_attribute": "segments",
+            "room_id_key": "id", "room_name_key": "name", "implicit_map_id": "main",
+        },
+    })
+    hass.states.async_set("sensor.alfred_map", "6")
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    assert get_active_map_id(hass, _VAC) == "6"
+
+
+def test_active_map_unavailable_not_implicit(hass, manager):
+    """[RD-10] a DECLARED but unavailable active_map entity → None. It must NOT
+    fall back to the implicit id — that would fork a second map for a device
+    whose real map is merely offline for a moment."""
+    register_adapter_config(_VAC, {
+        "adapter_id": "test", "source": "test",
+        "entities": {"active_map": "sensor.alfred_map"},
+        "discovery": {
+            "room_list_entity": "vacuum_entity", "room_list_attribute": "segments",
+            "room_id_key": "id", "room_name_key": "name", "implicit_map_id": "main",
+        },
+    })
+    hass.states.async_set("sensor.alfred_map", "unavailable")
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    assert get_active_map_id(hass, _VAC) is None
+
+
+def test_active_map_implicit_only_for_vacuum_attribute(hass, manager):
+    """[RD-11] implicit map only applies to the vacuum-attribute room source."""
+    _attribute_mode_adapter(room_list_entity="sensor.alfred_rooms")
+    hass.states.async_set("sensor.alfred_rooms", "ok",
+                          {"segments": [{"id": 1, "name": "Kitchen"}]})
+    assert get_active_map_id(hass, _VAC) is None
+
+
+def test_discover_attribute_mode_end_to_end(hass, manager):
+    """[RD-12] scalar/Tuya path: no active_map entity, rooms import under the
+    implicit id — the exact scenario behind the 'No active map' import block."""
+    _attribute_mode_adapter()
+    hass.states.async_set(_VAC, "docked", {"segments": [
+        {"id": 1, "name": "Kitchen"},
+        {"id": 2, "name": "Bath"},
+    ]})
+    map_id = get_active_map_id(hass, _VAC)
+    assert map_id == "main"
+    rooms = discover_rooms_for_vacuum(hass, vacuum_entity_id=_VAC, map_id=map_id)
+    assert [r["room_id"] for r in rooms] == [1, 2]
+    assert rooms[0]["map_id"] == "main"
 
 
 def test_discover_rooms_from_other_entity(hass, manager):


### PR DESCRIPTION
## Why

A real user (X10 Pro Omni on jeppesens `robovac_mqtt` 1.11.2) gets a red **"No active map detected"** warning on **Import Active Map**. Root cause: his robot is provisioned on Eufy's **scalar/Tuya transport** (robovac_mqtt `api_type: "scalar"`), which creates **no `active_map` sensor** — only `novel` (MQTT) devices get one. Every map-id resolver keyed off that missing entity and returned `None`, so the import blocked before transport-agnostic room discovery (which reads the `segments` attribute) ever ran.

## What

Give attribute-mode devices a single **implicit map id**, gated tightly so novel Eufy + Roborock are untouched:

- **`rooms/room_discovery.get_active_map_id`** — when an `active_map` entity *is* declared, trust it exclusively (a transiently-unavailable entity returns `None`, never forks a second map); when **none exists at all**, fall back to the adapter's `implicit_map_id` via `_implicit_attribute_map_id`, but only when the declared room-list attribute currently holds rooms.
- **`adapters/eufy`** — declare `discovery.implicit_map_id = "main"` + set the `has_attribute_rooms` hint from the `segments` attribute. Roborock (service-response source, no implicit id) opts out automatically.
- **`core/manager._resolve_active_map_id`** — delegates to `get_active_map_id` so import + runtime (external-run capture, dispatch) agree on `"main"`.
- **`core/capabilities`** — `supports_rooms`/`supports_segments` also true via the `has_attribute_rooms` hint; **`supports_active_map` stays strictly entity-gated** (no map entity to dereference).
- **`setup/workflow.import_active_map`** — blocked message is now transport-aware.
- **Prior commit** — model is read from the device registry, so scalar devices detect as `T2351 → x10` instead of generic.
- **`diagnostics`** — new interpreted `self_check` block (surfaced first) turns the raw signals into plain-English status lines (transport / room control / rooms_importable / map_image / model_detection / note).

## Tests

- `[RD-7..12]` — implicit-map path: implicit id when segments present, `None` when not, declared-entity-wins, **unavailable-entity must NOT fork an implicit map**, vacuum-attribute-only gating, scalar end-to-end import.
- `[CAP-9]` — `has_attribute_rooms` → `supports_rooms/segments` True while `supports_active_map` stays False.
- `[DIAG-8]` — `self_check` interprets the scalar transport, surfaced first.

## Status

**CI-validation PR — not for merge yet.** Pending: clone deploy confirms model→x10 + import goes green live, and the reporting user confirms #2/#3 end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)