### PR TITLE
fix(eufy): complete the scalar fix — dead-code + model_family (follow-up to #21)

### DIFF
--- a/custom_components/eufy_vacuum/adapters/eufy/adapter.py
+++ b/custom_components/eufy_vacuum/adapters/eufy/adapter.py
@@ -295,6 +295,16 @@ def register_eufy_adapter_for_vacuum(
         # app"); the card falls back to generic phrasing when absent.
         "brand": "Eufy",
 
+        # Model family + the model-based capability hints used to build the caps
+        # below. Stored so a later capability REFRESH (core/manager
+        # .refresh_vacuum_capabilities) reproduces the SAME detect_capabilities
+        # inputs as startup. Without these, a refresh reverts model_family to
+        # "generic" (detect_capabilities' default) and drops INPUT-ONLY hints such
+        # as has_attribute_rooms (which gates attribute-mode / scalar room support).
+        # Brand-agnostic: the manager passes through whatever the adapter stores.
+        "model_family": model_family,
+        "capability_hints": dict(capability_hints),
+
         "entities": entities,
 
         # External-run capture: the global select entities that reflect the

--- a/custom_components/eufy_vacuum/core/manager.py
+++ b/custom_components/eufy_vacuum/core/manager.py
@@ -1020,11 +1020,24 @@ class EufyVacuumManager:
         _entity_candidates: dict[str, list[str]] = {
             k: [v] for k, v in _adapter_entities.items() if v
         }
-        _capability_hints: dict[str, bool] = {
-            k: bool(v)
-            for k, v in _adapter_cfg.get("capabilities", {}).items()
-            if isinstance(v, bool)
-        }
+        # Prefer the adapter's stored model_family + original capability_hints so a
+        # refresh reproduces the SAME detect_capabilities inputs as startup. Without
+        # this, a refresh reverts model_family to "generic" (detect_capabilities'
+        # default) and drops INPUT-ONLY hints like has_attribute_rooms (which gates
+        # attribute-mode / scalar room support). Adapters that publish no
+        # capability_hints fall back to deriving boolean hints from stored flags.
+        _model_family = _adapter_cfg.get("model_family")
+        _stored_hints = _adapter_cfg.get("capability_hints")
+        if isinstance(_stored_hints, dict) and _stored_hints:
+            _capability_hints: dict[str, bool] = {
+                k: bool(v) for k, v in _stored_hints.items() if isinstance(v, bool)
+            }
+        else:
+            _capability_hints = {
+                k: bool(v)
+                for k, v in _adapter_cfg.get("capabilities", {}).items()
+                if isinstance(v, bool)
+            }
         _maintenance_components = _adapter_cfg.get("maintenance_components") or None
 
         payload = detect_capabilities(
@@ -1032,6 +1045,7 @@ class EufyVacuumManager:
             vacuum_entity_id=vacuum_entity_id,
             detected_model=effective_model,
             entity_candidates=_entity_candidates or None,
+            model_family=_model_family,
             capability_hints=_capability_hints or None,
             maintenance_components=_maintenance_components,
         )

--- a/custom_components/eufy_vacuum/core/manager.py
+++ b/custom_components/eufy_vacuum/core/manager.py
@@ -1092,6 +1092,22 @@ class EufyVacuumManager:
                 detected_model=effective_model,
             )
 
+        # Self-heal stale persisted caps after a code update. The adapter config is
+        # recomputed fresh each boot; if its model_family no longer matches the
+        # persisted snapshot (e.g. a detection fix now resolves "x10" where stored
+        # caps say "generic"), re-detect so the snapshot — and everything derived
+        # from it, like supports_rooms in attribute mode — picks up the fix without
+        # a manual refresh. Fires only on a real mismatch (adapter declares a family
+        # AND it differs), so steady state never re-detects and adapters that
+        # publish no model_family are unaffected. Idempotent: the refresh writes the
+        # adapter's family back, so the next call matches.
+        _adapter_family = (_get_adapter_config(vacuum_entity_id) or {}).get("model_family")
+        if _adapter_family and stored.get("model_family") != _adapter_family:
+            return self.refresh_vacuum_capabilities(
+                vacuum_entity_id=vacuum_entity_id,
+                detected_model=effective_model,
+            )
+
         return stored
 
     def ensure_runtime(self, vacuum_entity_id: str) -> VacuumRuntimeState:

--- a/custom_components/eufy_vacuum/rooms/room_discovery.py
+++ b/custom_components/eufy_vacuum/rooms/room_discovery.py
@@ -21,6 +21,7 @@ import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .utils import slugify_room_name
 from .source_refresh import (
@@ -31,51 +32,87 @@ from ..adapters.registry import get_adapter_config
 
 _LOGGER = logging.getLogger(__name__)
 
+# HA sentinel states that mean "no usable value".
+_ACTIVE_MAP_SENTINELS = {"unknown", "unavailable", "", "none", "None"}
+
 
 def get_active_map_id(hass: HomeAssistant, vacuum_entity_id: str) -> str | None:
     """Return the active map ID for a vacuum, if available.
 
-    Reads the entity declared as entities.active_map in the adapter config. When
-    the device exposes that entity (novel Eufy / Roborock) it is the single
-    source of truth. When NO active_map entity exists at all — an attribute-mode
-    device, e.g. Eufy on the scalar/Tuya transport, which surfaces its room list
-    as a vacuum attribute but creates no map sensor — fall back to the adapter's
-    single implicit map id (see _implicit_attribute_map_id). Returns None when
-    neither path yields an id.
+    The adapter declares ``entities.active_map`` from a NAMING PATTERN for every
+    device, so the config always carries an entity id — "declared" does NOT mean
+    "exists". Resolution therefore keys off whether the entity actually exists:
+
+    - Entity present in the state machine → it is the single source of truth
+      (a sentinel value returns None — wait, don't fork a second map).
+    - Entity absent from the state machine but present in the ENTITY REGISTRY →
+      a novel device whose sensor hasn't materialised yet (boot/restart window):
+      return None and wait. Must NOT fork a phantom implicit map.
+    - Entity absent from BOTH state machine and registry → the sensor is never
+      created: an attribute-mode device (e.g. Eufy on the scalar/Tuya transport)
+      that surfaces its room list as a vacuum attribute. Fall back to the
+      adapter's single implicit map id (see _implicit_attribute_map_id).
+
+    Returns None when no path yields an id.
     """
     config = get_adapter_config(vacuum_entity_id)
     active_map_entity = (config or {}).get("entities", {}).get("active_map")
 
     if active_map_entity:
-        # Entity present: trust it exclusively. A transiently unavailable entity
-        # returns None (wait for it) rather than forking a second implicit map.
         state = hass.states.get(active_map_entity)
-        if state is None:
-            _LOGGER.debug("Active map entity %s missing for %s", active_map_entity, vacuum_entity_id)
+        if state is not None:
+            value = state.state
+            if value in _ACTIVE_MAP_SENTINELS:
+                _LOGGER.debug(
+                    "Active map entity %s sentinel value for %s: %s",
+                    active_map_entity, vacuum_entity_id, value,
+                )
+                return None
+            return str(value)
+        # Declared but not in the state machine. Distinguish a registered-but-
+        # not-yet-materialised sensor (novel boot race → wait) from a sensor that
+        # is never created (scalar/attribute mode → implicit fallback).
+        if _entity_registered(hass, active_map_entity):
+            _LOGGER.debug(
+                "Active map entity %s registered but no state yet for %s — waiting",
+                active_map_entity, vacuum_entity_id,
+            )
             return None
-        value = state.state
-        if value in {"unknown", "unavailable", "", "none", "None"}:
-            _LOGGER.debug("Active map entity invalid value for %s: %s", vacuum_entity_id, value)
-            return None
-        return str(value)
+        _LOGGER.debug(
+            "Active map entity %s declared but never created for %s — trying "
+            "implicit attribute map", active_map_entity, vacuum_entity_id,
+        )
 
-    # No active_map entity declared — attribute-mode fallback.
-    _LOGGER.debug("No active_map entity for %s — trying implicit attribute map", vacuum_entity_id)
     return _implicit_attribute_map_id(hass, vacuum_entity_id, config)
+
+
+def _entity_registered(hass: HomeAssistant, entity_id: str) -> bool:
+    """True if entity_id exists in the HA entity registry.
+
+    Used to tell a sensor that is momentarily stateless (registered, e.g. during
+    a restart) from one that is never created at all (the scalar transport never
+    registers an active_map sensor). Defensive — never raises.
+    """
+    try:
+        return er.async_get(hass).async_get(entity_id) is not None
+    except Exception:  # pragma: no cover - defensive
+        return False
 
 
 def _implicit_attribute_map_id(
     hass: HomeAssistant, vacuum_entity_id: str, config: dict | None
 ) -> str | None:
-    """Single implicit map id for an attribute-mode device (no active_map entity).
+    """Single implicit map id for an attribute-mode device (no active_map sensor).
 
     A device that exposes its room list as a vacuum-entity attribute but creates
     no active_map sensor still has exactly one map. When the adapter declares
-    ``discovery.implicit_map_id`` AND that room-list attribute currently holds a
-    non-empty list, return the implicit id so import/discovery have an anchor.
-    Returns None otherwise — so brands that don't opt in (Roborock, which uses a
-    service-response source and sets no implicit_map_id) are unaffected, and the
-    implicit map never appears for a device with no rooms.
+    ``discovery.implicit_map_id`` AND that room-list attribute currently holds at
+    least one room-shaped (dict) row, return the implicit id so import/discovery
+    have an anchor. Returns None otherwise — so brands that don't opt in
+    (Roborock, which uses a service-response source and sets no implicit_map_id)
+    are unaffected, and the implicit map never appears for a device that exposes
+    no usable rooms (an empty or all-junk segments list — which discovery would
+    reject anyway).
     """
     discovery = (config or {}).get("discovery", {}) or {}
     implicit = discovery.get("implicit_map_id")
@@ -85,7 +122,9 @@ def _implicit_attribute_map_id(
         return None
     state = hass.states.get(vacuum_entity_id)
     rooms = state.attributes.get(attr) if state is not None else None
-    if isinstance(rooms, list) and rooms:
+    # Require at least one dict row — a non-empty list of non-dicts is not a usable
+    # room list and must not anchor a phantom map (matches discover_rooms' filter).
+    if isinstance(rooms, list) and any(isinstance(r, dict) for r in rooms):
         return str(implicit)
     return None
 

--- a/tests/integration/test_core_capabilities.py
+++ b/tests/integration/test_core_capabilities.py
@@ -17,6 +17,9 @@ Coverage targets
          mop-derived default (the Roborock S6 declares it False — water is unsettable).
 [CAP-9]  detect_capabilities: has_attribute_rooms hint reports rooms/segments support
          WITHOUT a map entity (scalar/Tuya transport); supports_active_map stays False.
+[CAP-10] refresh_vacuum_capabilities reproduces startup inputs: re-passes the adapter's
+         stored model_family + capability_hints, so a refresh keeps model_family (not
+         "generic") and keeps has_attribute_rooms (scalar supports_rooms).
 """
 
 from __future__ import annotations
@@ -28,6 +31,7 @@ from custom_components.eufy_vacuum.core.capabilities import (
     _find_registry_entity_by_tokens,
     detect_capabilities,
 )
+from custom_components.eufy_vacuum.adapters.registry import register_adapter_config
 
 from homeassistant.helpers import entity_registry as er
 
@@ -225,3 +229,34 @@ def test_get_vacuum_capabilities_refreshes_when_model_newly_known(manager):
     out = manager.get_vacuum_capabilities(
         vacuum_entity_id=_VAC, detected_model="X8", refresh=False)
     assert out["detected_model"] == "X8"
+
+
+def test_refresh_preserves_model_family_and_attribute_room_hint(hass, manager):
+    """[CAP-10] A capability REFRESH must reproduce the SAME detect_capabilities
+    inputs as startup by re-passing the adapter's stored model_family +
+    capability_hints. Without that, refresh_vacuum_capabilities omits model_family
+    (detect_capabilities defaults it to 'generic') and drops INPUT-ONLY hints like
+    has_attribute_rooms — so an attribute-mode/scalar device silently loses
+    supports_rooms on any refresh. Guards the live regression observed on an X10
+    (detected_model 'T2351' but model_family 'generic')."""
+    register_adapter_config(_VAC, {
+        "adapter_id": "test", "source": "test",
+        # Attribute-mode shape: NO active_map entity at all.
+        "entities": {"vacuum": _VAC},
+        "model_family": "x10",
+        "capability_hints": {"has_attribute_rooms": True, "supports_mop_wash": True},
+        # The curated capabilities subset deliberately lacks model_family /
+        # has_attribute_rooms — proving the fix reads capability_hints, not this.
+        "capabilities": {"supports_path_control": True},
+    })
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+
+    caps = manager.refresh_vacuum_capabilities(
+        vacuum_entity_id=_VAC, detected_model="T2351")
+
+    assert caps["detected_model"] == "T2351"
+    assert caps["model_family"] == "x10"          # preserved, NOT reverted to "generic"
+    assert caps["supports_rooms"] is True          # via the has_attribute_rooms hint
+    assert caps["supports_segments"] is True
+    assert caps["supports_active_map"] is False    # no active_map entity to dereference
+    assert caps["supports_mop_wash"] is True       # stored hint honored on refresh

--- a/tests/integration/test_core_capabilities.py
+++ b/tests/integration/test_core_capabilities.py
@@ -20,6 +20,8 @@ Coverage targets
 [CAP-10] refresh_vacuum_capabilities reproduces startup inputs: re-passes the adapter's
          stored model_family + capability_hints, so a refresh keeps model_family (not
          "generic") and keeps has_attribute_rooms (scalar supports_rooms).
+[CAP-11] get_vacuum_capabilities self-heals a stale persisted model_family: re-detects
+         (even refresh=False) when the adapter now declares a different family; idempotent.
 """
 
 from __future__ import annotations
@@ -260,3 +262,32 @@ def test_refresh_preserves_model_family_and_attribute_room_hint(hass, manager):
     assert caps["supports_segments"] is True
     assert caps["supports_active_map"] is False    # no active_map entity to dereference
     assert caps["supports_mop_wash"] is True       # stored hint honored on refresh
+
+
+def test_get_vacuum_capabilities_self_heals_stale_model_family(hass, manager):
+    """[CAP-11] A persisted snapshot with a stale model_family ("generic") is
+    re-detected when the freshly-registered adapter now declares a better family
+    ("x10") — so a detection fix lands on existing installs without a manual
+    refresh, even with refresh=False. Idempotent: once healed, stored matches the
+    adapter family so it does not re-detect again. (This is what made the live X10
+    keep reading "generic" until the adapter began publishing model_family.)"""
+    register_adapter_config(_VAC, {
+        "adapter_id": "test", "source": "test",
+        "entities": {"active_map": "sensor.alfred_map"},
+        "model_family": "x10",
+        "capability_hints": {"supports_mop_wash": True},
+        "capabilities": {},
+    })
+    hass.states.async_set("sensor.alfred_map", "6")
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    # Stale persisted snapshot (pre-fix): detected_model set, model_family generic.
+    manager.data.setdefault("capabilities", {})[_VAC] = {
+        "detected_model": "T2351", "model_family": "generic", "supports_rooms": True,
+    }
+
+    out = manager.get_vacuum_capabilities(vacuum_entity_id=_VAC, refresh=False)
+    assert out["model_family"] == "x10"            # self-healed
+    assert out["supports_mop_wash"] is True        # via the stored hint
+
+    # The refresh wrote the adapter family back, so the mismatch is gone.
+    assert manager.data["capabilities"][_VAC]["model_family"] == "x10"

--- a/tests/integration/test_room_discovery.py
+++ b/tests/integration/test_room_discovery.py
@@ -10,17 +10,22 @@ Coverage targets
 [RD-4] discover_rooms_for_vacuum: incomplete discovery config → [].
 [RD-5] discover_rooms_payload wraps the room list with counts.
 [RD-6] room_list_entity = concrete entity id sources from that entity, not the vacuum.
-[RD-7] attribute mode (no active_map entity) + implicit_map_id + segments → implicit id.
-[RD-8] implicit_map_id declared but no rooms visible → None (no phantom map).
-[RD-9] a declared active_map entity wins; implicit never fires alongside it.
-[RD-10] a declared-but-unavailable active_map entity → None (must not fork an implicit map).
+[RD-7] attribute mode — active_map DECLARED but the entity never created (scalar)
+       + implicit_map_id + segments → implicit id.
+[RD-8] scalar shape but no rooms visible → None (no phantom map).
+[RD-9] a declared active_map entity that EXISTS (has state) wins; implicit never fires.
+[RD-10] a declared active_map entity present with a sentinel value → None (don't fork).
 [RD-11] implicit map only applies to the vacuum-attribute source.
 [RD-12] end-to-end: scalar/Tuya path imports rooms under the implicit id.
+[RD-13] BOOT RACE: active_map declared + REGISTERED but stateless → None (must NOT fork
+        a phantom map for a novel device whose sensor hasn't materialised yet).
 """
 
 from __future__ import annotations
 
 import pytest
+
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.eufy_vacuum.adapters.registry import register_adapter_config
 from custom_components.eufy_vacuum.rooms.room_discovery import (
@@ -96,10 +101,16 @@ def test_discover_payload(hass, manager):
 
 
 def _attribute_mode_adapter(*, implicit="main", room_list_entity="vacuum_entity"):
-    """Adapter with NO active_map entity (scalar/Tuya Eufy) + an implicit map id."""
+    """Real scalar/Tuya shape: the adapter DECLARES active_map from its naming
+    pattern (every Eufy device does, existence-unchecked), but the scalar
+    transport never creates that sensor — so the declared entity is absent from
+    BOTH the state machine and the entity registry. Tests using this must NOT
+    create or register sensor.alfred_map; that absence is what selects the
+    attribute-mode path."""
     register_adapter_config(_VAC, {
         "adapter_id": "test", "source": "test",
-        "entities": {},  # the scalar transport creates no active_map sensor
+        # DECLARED (like the real adapter) but never created on the scalar transport.
+        "entities": {"active_map": "sensor.alfred_map"},
         "discovery": {
             "room_list_entity": room_list_entity,
             "room_list_attribute": "segments",
@@ -111,49 +122,56 @@ def _attribute_mode_adapter(*, implicit="main", room_list_entity="vacuum_entity"
 
 
 def test_active_map_implicit_attribute_mode(hass, manager):
-    """[RD-7] no active_map entity + implicit_map_id + segments → implicit id."""
+    """[RD-7] active_map declared but the entity is absent from HA (scalar) +
+    implicit_map_id + segments → implicit id. (Regression guard: the adapter
+    ALWAYS declares active_map, so 'declared' must not block the fallback.)"""
     _attribute_mode_adapter()
     hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    # sensor.alfred_map is intentionally never created → attribute-mode.
     assert get_active_map_id(hass, _VAC) == "main"
 
 
 def test_active_map_implicit_no_segments(hass, manager):
-    """[RD-8] implicit declared but no rooms visible → None (no phantom map)."""
+    """[RD-8] scalar shape but no usable rooms → None (no phantom map)."""
     _attribute_mode_adapter()
     hass.states.async_set(_VAC, "docked", {"segments": []})
     assert get_active_map_id(hass, _VAC) is None
     hass.states.async_set(_VAC, "docked", {})  # attribute entirely absent
     assert get_active_map_id(hass, _VAC) is None
+    hass.states.async_set(_VAC, "docked", {"segments": ["junk", 5]})  # no dict rows
+    assert get_active_map_id(hass, _VAC) is None
 
 
 def test_active_map_entity_wins_over_implicit(hass, manager):
-    """[RD-9] a present active_map entity wins; implicit never fires alongside it."""
-    register_adapter_config(_VAC, {
-        "adapter_id": "test", "source": "test",
-        "entities": {"active_map": "sensor.alfred_map"},
-        "discovery": {
-            "room_list_entity": "vacuum_entity", "room_list_attribute": "segments",
-            "room_id_key": "id", "room_name_key": "name", "implicit_map_id": "main",
-        },
-    })
-    hass.states.async_set("sensor.alfred_map", "6")
+    """[RD-9] a present active_map entity (real state) wins; implicit never fires."""
+    _attribute_mode_adapter()
+    hass.states.async_set("sensor.alfred_map", "6")  # entity EXISTS with a value
     hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
     assert get_active_map_id(hass, _VAC) == "6"
 
 
 def test_active_map_unavailable_not_implicit(hass, manager):
-    """[RD-10] a DECLARED but unavailable active_map entity → None. It must NOT
-    fall back to the implicit id — that would fork a second map for a device
+    """[RD-10] a present active_map entity with a sentinel value → None. It must
+    NOT fall back to the implicit id — that would fork a second map for a device
     whose real map is merely offline for a moment."""
-    register_adapter_config(_VAC, {
-        "adapter_id": "test", "source": "test",
-        "entities": {"active_map": "sensor.alfred_map"},
-        "discovery": {
-            "room_list_entity": "vacuum_entity", "room_list_attribute": "segments",
-            "room_id_key": "id", "room_name_key": "name", "implicit_map_id": "main",
-        },
-    })
-    hass.states.async_set("sensor.alfred_map", "unavailable")
+    _attribute_mode_adapter()
+    hass.states.async_set("sensor.alfred_map", "unavailable")  # exists, sentinel
+    hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
+    assert get_active_map_id(hass, _VAC) is None
+
+
+def test_active_map_registered_but_stateless_boot_race(hass, manager):
+    """[RD-13] active_map declared + REGISTERED in the entity registry but with no
+    state yet (novel device, restart window) → None. Must NOT fork a phantom
+    'main' map even though segments are already populated — registry presence
+    distinguishes this from the scalar transport (which never registers it)."""
+    _attribute_mode_adapter()
+    # Register sensor.alfred_map WITHOUT setting a state (the boot-race window).
+    er.async_get(hass).async_get_or_create(
+        "sensor", "eufy_vacuum", "alfred_map_unique",
+        suggested_object_id="alfred_map",
+    )
+    assert hass.states.get("sensor.alfred_map") is None  # registered, no state
     hass.states.async_set(_VAC, "docked", {"segments": [{"id": 1, "name": "Kitchen"}]})
     assert get_active_map_id(hass, _VAC) is None
 
@@ -167,8 +185,8 @@ def test_active_map_implicit_only_for_vacuum_attribute(hass, manager):
 
 
 def test_discover_attribute_mode_end_to_end(hass, manager):
-    """[RD-12] scalar/Tuya path: no active_map entity, rooms import under the
-    implicit id — the exact scenario behind the 'No active map' import block."""
+    """[RD-12] scalar/Tuya path: active_map declared but absent, rooms import
+    under the implicit id — the exact scenario behind the 'No active map' block."""
     _attribute_mode_adapter()
     hass.states.async_set(_VAC, "docked", {"segments": [
         {"id": 1, "name": "Kitchen"},


### PR DESCRIPTION
## Why this exists

[#21](https://github.com/kingchddg901/Vacuum_Agent/pull/21) was merged at commit `77784ca`, which captured only the **first cut** of the scalar fix. Adversarial review + live clone validation then surfaced two problems that are fixed in the three commits below — none of which made it into that merge. This PR brings master to the actually-working, validated state.

## What's in here (3 commits)

1. **`5dc9ded` — preserve model_family + input hints across a capability refresh.** `refresh_vacuum_capabilities` re-ran detection without `model_family`, so it reverted to `"generic"` (live-confirmed on an X10: `detected_model "T2351"` but `model_family "generic"`). The same gap dropped input-only hints like `has_attribute_rooms`, regressing scalar `supports_rooms`. The adapter now publishes `model_family` + its hints; the manager re-passes them. Brand-agnostic; Roborock unaffected.

2. **`63421b8` — self-heal stale persisted caps.** Capabilities are persisted in `.storage`; on restart `get_vacuum_capabilities(refresh=False)` returned the stale snapshot without re-detecting (the "newly-known model" trigger can't fire when `detected_model` is already set). Now it re-detects when the freshly-registered adapter's `model_family` disagrees with the snapshot — so the fix lands on existing installs (and Peter) without manual intervention. Idempotent.

3. **`a53513c` — the critical dead-code fix.** The original scalar fix was **dead code**: the Eufy adapter declares `entities.active_map` from a naming pattern for *every* device (existence-unchecked), so `get_active_map_id`'s `if active_map_entity:` gate always took the entity branch and never reached the implicit fallback — Peter would still have been blocked. Now it gates on entity **existence**, using the entity registry to distinguish a scalar device (sensor never created → implicit map) from a novel device mid-boot (sensor registered but stateless → wait, don't fork a phantom map). Tests rewritten to the **real** shape (`active_map` declared but absent) — the old tests passed against the wrong shape — plus a boot-race guard.

## Validation

- Clone (novel X10) confirmed: no regression, `model_detection: T2351 → x10` after the self-heal, and a fresh delete+re-add also lands `x10`.
- Scalar end-to-end still needs a scalar-provisioned device (Peter) — the clone is novel.
- CI on this PR is the first run over the rewritten RD-7..13 / CAP-9..11 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)