### PR TITLE
release: bump manifest to 1.3.0

### DIFF
--- a/custom_components/eufy_vacuum/manifest.json
+++ b/custom_components/eufy_vacuum/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/kingchddg901/Vacuum_Agent/issues",
   "requirements": [],
-  "version": "1.2.5"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
The 1.3.0 manifest version bump (the prior release PR #27 merged the README + codeowner fix, but this commit hadn't been pushed yet). Master CHANGELOG already has the [1.3.0] section. After merge: tag `v1.3.0` + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)