### PR TITLE
fix(jobs): stuck-watch tick raises NameError on every call (undefined get_adapter_config)

### DIFF
--- a/custom_components/eufy_vacuum/core/manager.py
+++ b/custom_components/eufy_vacuum/core/manager.py
@@ -4700,7 +4700,7 @@ class EufyVacuumManager:
         if not active_job:
             return {"fired": None, "reason": "no_job"}
 
-        adapter_cfg = get_adapter_config(vacuum_entity_id) or {}
+        adapter_cfg = _get_adapter_config(vacuum_entity_id) or {}
         limits = stuck_watch.tunables(adapter_cfg)
         now_iso = utc_now_iso()
 


### PR DESCRIPTION
### The bug

`core/manager.py` imports the registry helper under an alias:

```python
from ..adapters.registry import (
    adapter_honors_clean_order,
    get_adapter_config as _get_adapter_config,
)
```

All ten other call sites in that module use `_get_adapter_config`. The one inside
`apply_stuck_watch_tick` uses the bare `get_adapter_config`, which is never bound in the
module namespace:

```python
adapter_cfg = get_adapter_config(vacuum_entity_id) or {}   # master, line 4703
```

So the call raises on every invocation:

```
File "/config/custom_components/eufy_vacuum/core/manager.py", line 4532, in apply_stuck_watch_tick
    adapter_cfg = get_adapter_config(vacuum_entity_id) or {}
NameError: name 'get_adapter_config' is not defined. Did you mean: '_get_adapter_config'?
```

### Impact

`listeners/job_progress.py` calls `apply_stuck_watch_tick` from the 5-second ticker inside
its own `try/except` — that containment worked exactly as the comment intends, so the
progress tick, room rollover and the live card view were never affected.

But it means **both stuck triggers (error-edge and area-window) have never fired since the
feature landed in 26c4b2d** — the failure was silent apart from the log. While a run is in
flight the traceback lands at ~720 entries/hour; on my instance it produced 37,904 entries
over seven days, which is what led me to it.

It also has a real cost beyond noise: a strict-order run on my Roborock stalled and sat
unfinalized for 49 hours, and stuck detection is precisely the thing that should have
surfaced it.

### The fix

One character — use the alias, matching the other ten call sites in the file.

```diff
-        adapter_cfg = get_adapter_config(vacuum_entity_id) or {}
+        adapter_cfg = _get_adapter_config(vacuum_entity_id) or {}
```

### Notes

- Reproduced on **v2.0.1** (latest stable); the bare call is still on `master` today, so
  the `v2.1.0-beta` line carries it too.
- I could not find an existing issue or PR covering this (checked all open/closed issues
  and PRs).
- Verified the patched file byte-for-byte on my production instance: it compiles, and
  `grep` confirms every `get_adapter_config(vacuum_entity_id)` call site now carries the
  leading underscore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
