### PR TITLE
feat(roborock): catalogue the Q5 Pro (a72) as mop-unsettable

### DIFF
--- a/custom_components/eufy_vacuum/adapters/roborock/model_catalog.py
+++ b/custom_components/eufy_vacuum/adapters/roborock/model_catalog.py
@@ -47,6 +47,25 @@ MODEL_PROFILES: dict[str, dict] = {
         # No path/route axis on this unit — owner-confirmed on hardware.
         "has_path_control": False,
     },
+    # Same class as the S6, and catalogued for the same reason: the mop-intensity and
+    # mop-mode selects EXIST (the unit ships with a pad + tank) but the SETs are rejected
+    # on-device with RoborockUnsupportedFeature -- observed on every phase dispatch on
+    # hardware. Without this entry an a72 falls through to DEFAULT_PROFILE (mop_settable
+    # True) and is offered water pickers it can never honour.
+    "roborock.vacuum.a72": {  # Q5 Pro
+        "family": "q5",
+        "display_name": "Roborock Q5 Pro",
+        # Charge-only base. The core roborock integration creates no auto-empty / wash /
+        # dry entities for this unit, so there is no station to model.
+        "has_dock": False,
+        # Carries a mop pad + water tank...
+        "has_mop": True,
+        # ...but SET_WATER_BOX_CUSTOM_MODE is rejected on-device, and
+        # binary_sensor.<obj>_water_box_attached reads unavailable.
+        "mop_settable": False,
+        "supports_segments": True,
+        "has_path_control": False,
+    },
     # Settable-mop models. device.model codes are best-effort from python-roborock's
     # model table; if a code is wrong the profile simply never matches and the unit
     # falls through to DEFAULT_PROFILE (also mop_settable), so mop controls still


### PR DESCRIPTION
### What

Adds a `roborock.vacuum.a72` (Roborock Q5 Pro) entry to `MODEL_PROFILES`, with
`mop_settable: False` and `has_dock: False`.

### Why

`MODEL_PROFILES` ships `s6`, `a15` (S7) and `a70` (S8). A Q5 Pro therefore falls through
to `DEFAULT_PROFILE`, which assumes `mop_settable: True` on the documented reasoning that
"not all Roborocks are the S6".

The Q5 Pro *is* the S6 case:

- `select.<obj>_mop_intensity` exists but sits at `unknown`
- `binary_sensor.<obj>_water_box_attached` reads `unavailable`
- the mop `global_pre_call` is rejected on-device on **every** phase dispatch:

```
[eufy_vacuum.dispatch.manager] global pre-call select.select_option failed for vacuum.vlad
roborock.exceptions.RoborockUnsupportedFeature: The method called is not recognized by the device.
```

To be clear about severity: this is the **log-and-continue** branch of
`_run_global_pre_calls`, not the abort — my daily run is all-vacuum, so `_use_safest` is
false and the dispatch proceeds normally. So it is noise rather than a broken run. But it
fires on every dispatch, and more importantly `supports_water_control` was `True`, putting
water/mop pickers in the UI for a control the hardware ignores — which
`model_catalog.py`'s own comment on `has_path_control` calls out as the worse failure mode.

### `has_dock: False`

Verified on hardware: the core `roborock` integration creates no auto-empty / wash / dry
entities for this unit — 36 roborock-platform entities, none of them station controls.
Same reasoning as the existing S6 entry.

### Verified after the change

On a live instance, `eufy_vacuum.get_adapter_config` for the Q5 Pro now returns:

| field | before | after |
|---|---|---|
| `display_name` | (generic) | `Roborock Q5 Pro` |
| `supports_water_control` | `True` | `False` |
| `dispatch.global_pre_calls` | mop water pre-call | `null` |

Fan control is unaffected — it rides `dispatch.per_room_live_settings`
(`vacuum.set_fan_speed`), which is untouched. `supports_room_profiles` correctly follows
`mop_settable` to `False`, which matches the intent in the code comment (a profile on a
globally-unsettable model would be "a degenerate named fan speed"); the instance had 0
defined profiles either way, so nothing was lost.

Separate from #52, which fixes the `NameError` in `apply_stuck_watch_tick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
